### PR TITLE
these are all good changes and - when combined with appropriate settings in a `.env` file result in a working app

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "name": "org-sync-app",
+    "name": "hts-ccoe-org-sync-repo-operations",
     "version": "0.1.0",
     "description": "Syncs GitHub orgs and their repos",
     "author": "Assaf Stone, @devopsjester",
@@ -10,7 +10,7 @@
             "syncPullRequests": true
         },
         "shadows": [
-            "org-sync-target"
+            "hts-ccoe-test"
         ],
         "whitelist": [
             ".*"

--- a/handlers/pushes.js
+++ b/handlers/pushes.js
@@ -62,13 +62,14 @@ async function initializeGitRepo(directory, owner, repo, token) {
         console.log(`Initialized git repository in ${directory}`);
 
         const remoteUrl = `https://${token}@github.com/${owner}/${repo}.git`;
+        const remoteUrlMasked = `https://ghp_xxxx@github.com/${owner}/${repo}.git`;
         const isRemoteExist = await git.getRemotes(false).then(remotes => remotes.some(remote => remote.name === 'origin'));
         if (isRemoteExist) {
             await git.removeRemote('origin');
         }
         await git.addRemote('origin', remoteUrl);
 
-        console.log(`Added remote origin ${remoteUrl}`);
+        console.log(`Added remote origin ${remoteUrlMasked}`);
 
         return git;
     } catch (error) {
@@ -114,12 +115,13 @@ async function pushToShadowRepos(git, shadowRepo, token) {
     try {
         // add a remote to the shadow repo called 'target'
         const shadowUrl = `https://${token}@github.com/${shadowRepo}.git`;
+        const shadowUrlMasked = `https://ghp_xxxx@github.com/${shadowRepo}.git`;
         const isShadowRemoteExist = await git.getRemotes(false).then(remotes => remotes.some(remote => remote.name === 'target'));
         if (isShadowRemoteExist) {
             await git.removeRemote('target');
         }
         await git.addRemote('target', shadowUrl);
-        console.log(`Added remote target ${shadowUrl}`);
+        console.log(`Added remote target ${shadowUrlMasked}`);
 
         // push all branches to the shadow repo
         await git.push('target', '--all');


### PR DESCRIPTION
- output the user the application is authenticated as
- change the order so that pushes are handled prior to pull requests
- update the name of the application
- update the name of the shadow Organization
- mask the PAT of the new github user so that it does not show up in logs